### PR TITLE
V2migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,42 +20,42 @@
 buildscript {
     repositories {
         maven {
-            url "http://repo.springsource.org/plugins-release";
-            mavenCentral();
+            url "http://repo.springsource.org/plugins-release"
+            mavenCentral()
         }
     }
     dependencies {
         classpath(group: "org.springframework.build.gradle",
-            name: "propdeps-plugin", version: "0.0.7");
+            name: "propdeps-plugin", version: "0.0.7")
         classpath(group: "info.solidsoft.gradle.pitest",
-            name: "gradle-pitest-plugin", version: "1.1.1");
+            name: "gradle-pitest-plugin", version: "1.1.1")
     }
-};
+}
 
-apply(plugin: "java");
-apply(plugin: "maven");
-apply(plugin: "signing");
-apply(plugin: "osgi");
-apply(plugin: "idea");
-apply(plugin: "eclipse");
-apply(plugin: "propdeps");
-apply(plugin: "propdeps-maven");
-apply(plugin: "propdeps-idea");
-apply(plugin: "propdeps-eclipse");
-apply(plugin: "info.solidsoft.pitest");
+apply(plugin: "java")
+apply(plugin: "maven")
+apply(plugin: "signing")
+apply(plugin: "osgi")
+apply(plugin: "idea")
+apply(plugin: "eclipse")
+apply(plugin: "propdeps")
+apply(plugin: "propdeps-maven")
+apply(plugin: "propdeps-idea")
+apply(plugin: "propdeps-eclipse")
+apply(plugin: "info.solidsoft.pitest")
 
-group = "com.github.fge";
-version = "0.0.2-SNAPSHOT";
-description = "FileSystem implementation over DropBox";
-sourceCompatibility = "1.7";
-targetCompatibility = "1.7"; // defaults to sourceCompatibility
+group = "com.github.fge"
+version = "0.0.2-SNAPSHOT"
+description = "FileSystem implementation over DropBox"
+sourceCompatibility = "1.7"
+targetCompatibility = "1.7" // defaults to sourceCompatibility
 
 /*
  * Repositories to use
  */
 repositories {
-    mavenCentral();
-    mavenLocal();
+    mavenCentral()
+    mavenLocal()
 }
 
 /*
@@ -63,63 +63,66 @@ repositories {
  */
 dependencies {
     compile(group: "com.github.fge", name: "java7-fs-base",
-        version: "0.0.2-SNAPSHOT");
+        version: "0.0.2-SNAPSHOT")
     compile(group: "com.dropbox.core", name: "dropbox-core-sdk",
-        version: "1.7.7");
+        version: "3.0.4")
     provided(group: "com.google.code.findbugs", name: "jsr305",
-        version: "3.0.0");
+        version: "3.0.0")
     testCompile(group: "org.testng", name: "testng", version: "6.8.8") {
-        exclude(group: "junit", module: "junit");
-        exclude(group: "org.beanshell", module: "bsh");
-        exclude(group: "org.yaml", module: "snakeyaml");
-    };
-    testCompile(group: "org.mockito", name: "mockito-core", version: "1.10.8");
-    testCompile(group: "org.assertj", name: "assertj-core", version: "1.7.0");
+        exclude(group: "junit", module: "junit")
+        exclude(group: "org.beanshell", module: "bsh")
+        exclude(group: "org.yaml", module: "snakeyaml")
+    }
+    testCompile(group: "org.mockito", name: "mockito-core", version: "1.10.8")
+    testCompile(group: "org.assertj", name: "assertj-core", version: "1.7.0")
+
+    testCompile(group: "com.github.marschall", name: "memoryfilesystem", version: "1.0.1")
+
 }
 
-javadoc.options.links("http://docs.oracle.com/javase/7/docs/api/");
-javadoc.options.links("http://jsr-305.googlecode.com/svn/trunk/javadoc/");
-javadoc.options.links("http://dropbox.github.io/dropbox-sdk-java/api-docs/v1.7.x/");
+javadoc.options.links("http://docs.oracle.com/javase/7/docs/api/")
+javadoc.options.links("http://jsr-305.googlecode.com/svn/trunk/javadoc/")
+javadoc.options.links("http://dropbox.github.io/dropbox-sdk-java/api-docs/v1.7.x/")
 
 /*
  * Necessary! Otherwise TestNG will not be used...
  */
 test {
     useTestNG() {
-        useDefaultListeners = true;
-    };
+        useDefaultListeners = true
+    }
 }
 
 pitest {
-    pitestVersion = "1.1.2"; // see https://github.com/hcoles/pitest/issues/150
+    pitestVersion = "1.1.2" // see https://github.com/hcoles/pitest/issues/150
 }
 
 /*
  * Necessary to generate the source and javadoc jars
  */
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources";
-    from sourceSets.main.allSource;
+    classifier = "sources"
+    from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = "javadoc";
-    from javadoc.destinationDir;
+    classifier = "javadoc"
+    from javadoc.destinationDir
 }
 
 artifacts {
-    archives jar;
-    archives sourcesJar;
-    archives javadocJar;
+    archives jar
+    archives sourcesJar
+    archives javadocJar
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = "2.2";
-    distributionUrl = "http://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip";
+    gradleVersion = "2.2"
+    distributionUrl = "http://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }
 
 task pom << {
-    pom {}.writeTo("${projectDir}/pom.xml");
+    pom {}.writeTo("${projectDir}/pom.xml")
 }
 
 /*
@@ -127,47 +130,47 @@ task pom << {
  */
 
 project.ext {
-    gitrwscm = sprintf("git@github.com:fge/%s", name);
-    gitroscm = sprintf("https://github.com/fge/%s.git", name);
-    projectURL = sprintf("https://github.com/fge/%s", name);
-    sonatypeStaging = "https://oss.sonatype.org/service/local/staging/deploy/maven2/";
-    sonatypeSnapshots = "https://oss.sonatype.org/content/repositories/snapshots/";
-};
+    gitrwscm = sprintf("git@github.com:fge/%s", name)
+    gitroscm = sprintf("https://github.com/fge/%s.git", name)
+    projectURL = sprintf("https://github.com/fge/%s", name)
+    sonatypeStaging = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+    sonatypeSnapshots = "https://oss.sonatype.org/content/repositories/snapshots/"
+}
 
 task checkSigningRequirements << {
-    def requiredProperties = [ "sonatypeUsername", "sonatypePassword" ];
-    def noDice = false;
+    def requiredProperties = [ "sonatypeUsername", "sonatypePassword" ]
+    def noDice = false
     requiredProperties.each {
         if (project.properties[it] == null) {
-            noDice = true;
+            noDice = true
             System.err.printf("property \"%s\" is not defined!")
         }
     }
     if (noDice)
         throw new IllegalStateException("missing required properties for " +
-            "upload");
+            "upload")
 }
 
 uploadArchives {
-    dependsOn(checkSigningRequirements);
+    dependsOn(checkSigningRequirements)
     repositories {
         mavenDeployer {
             beforeDeployment {
-                MavenDeployment deployment -> signing.signPom(deployment);
+                MavenDeployment deployment -> signing.signPom(deployment)
             }
 
             repository(url: "${sonatypeStaging}") {
                 authentication(
                     userName: project.properties["sonatypeUsername"],
                     password: project.properties["sonatypePassword"]
-                );
+                )
             }
 
             snapshotRepository(url: "${sonatypeSnapshots}") {
                 authentication(
                     userName: project.properties["sonatypeUsername"],
                     password: project.properties["sonatypePassword"]
-                );
+                )
             }
         }
     }
@@ -181,43 +184,43 @@ uploadArchives {
     uploadArchives.repositories.mavenDeployer
 ]*.pom*.whenConfigured { pom ->
     pom.project {
-        name "${project.name}";
-        packaging "jar";
-        description "${project.description}";
-        url "${projectURL}";
+        name "${project.name}"
+        packaging "jar"
+        description "${project.description}"
+        url "${projectURL}"
 
         scm {
-            url "${gitrwscm}";
-            connection "${gitrwscm}";
-            developerConnection "${gitroscm}";
+            url "${gitrwscm}"
+            connection "${gitrwscm}"
+            developerConnection "${gitroscm}"
         }
 
         licenses {
             license {
-                name "Lesser General Public License, version 3 or greater";
-                url "http://www.gnu.org/licenses/lgpl.html";
-                distribution "repo";
-            };
+                name "Lesser General Public License, version 3 or greater"
+                url "http://www.gnu.org/licenses/lgpl.html"
+                distribution "repo"
+            }
             license {
-                name "Apache Software License, version 2.0";
-                url "http://www.apache.org/licenses/LICENSE-2.0";
-                distribution "repo";
+                name "Apache Software License, version 2.0"
+                url "http://www.apache.org/licenses/LICENSE-2.0"
+                distribution "repo"
             }
         }
 
         developers {
             developer {
-                id "fge";
-                name "Francis Galiegue";
-                email "fgaliegue@gmail.com";
+                id "fge"
+                name "Francis Galiegue"
+                email "fgaliegue@gmail.com"
             }
         }
     }
 }
 
-ext.forRelease = !version.endsWith("-SNAPSHOT");
+ext.forRelease = !version.endsWith("-SNAPSHOT")
 signing {
-    required { forRelease && gradle.taskGraph.hasTask("uploadArchives") };
-    sign configurations.archives;
+    required { forRelease && gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
 }
 

--- a/src/main/java/com/github/fge/fs/dropbox/attr/DropBoxFileAttributesFactory.java
+++ b/src/main/java/com/github/fge/fs/dropbox/attr/DropBoxFileAttributesFactory.java
@@ -1,6 +1,6 @@
 package com.github.fge.fs.dropbox.attr;
 
-import com.dropbox.core.DbxEntry;
+import com.dropbox.core.v2.files.Metadata;
 import com.github.fge.filesystem.attributes.FileAttributesFactory;
 
 public final class DropBoxFileAttributesFactory
@@ -8,7 +8,7 @@ public final class DropBoxFileAttributesFactory
 {
     public DropBoxFileAttributesFactory()
     {
-        setMetadataClass(DbxEntry.class);
+        setMetadataClass(Metadata.class);
         addImplementation("basic", DropBoxBasicFileAttributesProvider.class);
     }
 }

--- a/src/main/java/com/github/fge/fs/dropbox/misc/DropBoxIOException.java
+++ b/src/main/java/com/github/fge/fs/dropbox/misc/DropBoxIOException.java
@@ -1,7 +1,7 @@
 package com.github.fge.fs.dropbox.misc;
 
-import com.dropbox.core.DbxClient;
 import com.dropbox.core.DbxException;
+import com.dropbox.core.v1.DbxClientV1;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -10,8 +10,8 @@ import java.io.IOException;
  * Class used as a wrapper over the DropBox API's unchecked exceptions when
  * an {@link IOException} is needed
  *
- * <p>The problem mainly comes from {@link DbxClient.Uploader} and {@link
- * DbxClient.Uploader}. Both of these methods define a {@code close()} method
+ * <p>The problem mainly comes from {@link DbxClientV1.Uploader} and {@link
+ * DbxClientV1.Uploader}. Both of these methods define a {@code close()} method
  * but none of them implement {@link Closeable}. Worse than that, at least as
  * far as the uploader is concerned, this method is not even idempotent, and all
  * exceptions it throws are <strong>unchecked</strong>.</p>

--- a/src/main/java/com/github/fge/fs/dropbox/misc/DropBoxInputStream.java
+++ b/src/main/java/com/github/fge/fs/dropbox/misc/DropBoxInputStream.java
@@ -1,6 +1,8 @@
 package com.github.fge.fs.dropbox.misc;
 
-import com.dropbox.core.DbxClient;
+import com.dropbox.core.DbxDownloader;
+import com.dropbox.core.v1.DbxClientV1;
+import com.dropbox.core.v2.files.FileMetadata;
 import com.github.fge.filesystem.driver.FileSystemDriver;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -10,7 +12,7 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 
 /**
- * Wrapper over {@link DbxClient.Downloader} extending {@link InputStream}
+ * Wrapper over {@link DbxClientV1.Downloader} extending {@link InputStream}
  *
  * <p>This class wraps a DropBox downloader class by extending {@code
  * InputStream} and delegating all of its methods to the downloader's
@@ -22,7 +24,7 @@ import java.nio.file.Path;
  * throw an exception; which means it may throw none, or it may throw an
  * <em>unchecked</em> exception. As such, the {@link #close()} method of this
  * class captures all {@link RuntimeException}s which {@link
- * DbxClient.Downloader#close()} may throw and wrap it into a {@link
+ * DbxClientV1.Downloader#close()} may throw and wrap it into a {@link
  * DropBoxIOException}. If the underlying input stream <em>did</em> throw an
  * exception, however, then such an exception is {@link
  * Throwable#addSuppressed(Throwable) suppressed}.</p>
@@ -34,13 +36,13 @@ import java.nio.file.Path;
 public final class DropBoxInputStream
     extends InputStream
 {
-    private final DbxClient.Downloader downloader;
+    private final DbxDownloader<FileMetadata> downloader;
     private final InputStream delegate;
 
-    public DropBoxInputStream(final DbxClient.Downloader downloader)
+    public DropBoxInputStream(final DbxDownloader<FileMetadata> downloader)
     {
         this.downloader = downloader;
-        delegate = downloader.body;
+        delegate = downloader.getInputStream();
     }
 
     @Override

--- a/src/main/java/com/github/fge/fs/dropbox/misc/DropBoxOutputStream.java
+++ b/src/main/java/com/github/fge/fs/dropbox/misc/DropBoxOutputStream.java
@@ -1,7 +1,8 @@
 package com.github.fge.fs.dropbox.misc;
 
-import com.dropbox.core.DbxClient;
 import com.dropbox.core.DbxException;
+import com.dropbox.core.v1.DbxClientV1;
+import com.dropbox.core.v2.files.UploadUploader;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -10,7 +11,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Wrapper over {@link DbxClient.Uploader} extending {@link OutputStream}
+ * Wrapper over {@link DbxClientV1.Uploader} extending {@link OutputStream}
  *
  * <p>This class wraps a DropBox downloader class by extending {@code
  * InputStream} and delegating all of its methods to the downloader's
@@ -22,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * throw an exception; which means it may throw none, or it may throw an
  * <em>unchecked</em> exception. As such, the {@link #close()} method of this
  * class captures all {@link RuntimeException}s which {@link
- * DbxClient.Uploader#close()} may throw and wrap it into a {@link
+ * DbxClientV1.Uploader#close()} may throw and wrap it into a {@link
  * DropBoxIOException}. If the underlying output stream <em>did</em> throw an
  * exception, however, then such an exception is {@link
  * Throwable#addSuppressed(Throwable) suppressed}.</p>
@@ -34,13 +35,14 @@ public final class DropBoxOutputStream
 {
     private final AtomicBoolean closeCalled = new AtomicBoolean(false);
 
-    private final DbxClient.Uploader uploader;
+    private final UploadUploader uploader;
     private final OutputStream out;
 
-    public DropBoxOutputStream(@Nonnull final DbxClient.Uploader uploader)
+    public DropBoxOutputStream(@Nonnull final UploadUploader uploader)
     {
+
         this.uploader = Objects.requireNonNull(uploader);
-        out = uploader.getBody();
+        out = uploader.getOutputStream();
     }
 
     @Override

--- a/src/main/java/com/github/fge/fs/dropbox/provider/DropBoxFileSystemRepository.java
+++ b/src/main/java/com/github/fge/fs/dropbox/provider/DropBoxFileSystemRepository.java
@@ -1,6 +1,6 @@
 package com.github.fge.fs.dropbox.provider;
 
-import com.dropbox.core.DbxClient;
+import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.DbxRequestConfig;
 import com.github.fge.filesystem.driver.FileSystemDriver;
 import com.github.fge.filesystem.provider.FileSystemRepositoryBase;
@@ -36,8 +36,8 @@ public final class DropBoxFileSystemRepository
         if (accessToken == null)
             throw new IllegalArgumentException("access token not found");
 
-        final DbxRequestConfig config = new DbxRequestConfig(NAME, LOCALE);
-        final DbxClient client = new DbxClient(config, accessToken);
+        final DbxRequestConfig config = DbxRequestConfig.newBuilder(NAME).withUserLocale(LOCALE).build();
+        final DbxClientV2 client = new DbxClientV2(config, accessToken);
         final DropBoxFileStore fileStore
             = new DropBoxFileStore(client,
             factoryProvider.getAttributesFactory());

--- a/src/test/java/com/github/fge/fs/dropbox/FileSystemTest.java
+++ b/src/test/java/com/github/fge/fs/dropbox/FileSystemTest.java
@@ -1,0 +1,451 @@
+package com.github.fge.fs.dropbox;
+
+import com.dropbox.core.util.IOUtil;
+import com.github.fge.filesystem.exceptions.ReadOnlyAttributeException;
+import com.github.fge.filesystem.provider.FileSystemRepository;
+import com.github.fge.fs.dropbox.misc.DropBoxIOException;
+import com.github.fge.fs.dropbox.provider.DropBoxFileSystemProvider;
+import com.github.fge.fs.dropbox.provider.DropBoxFileSystemRepository;
+import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AccessMode;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class FileSystemTest
+{
+    private static final String ACCESS_TOKEN = "AYN4WsiaBTgAAAAAAAAAIL4iJnTphS5Ou9kbp3Wu2xA0BvktlbJPWCDukj76qhbs";
+    private static FileSystemProvider provider;
+    private static URI uri;
+    private static Map<String, String> env;
+    private static String testDirectoryPath;
+
+
+    @BeforeClass
+    public static void setUpClass() throws Exception
+    {
+        uri = URI.create("dropbox://foo/");
+        env = new HashMap<>();
+        env.put("accessToken", ACCESS_TOKEN);
+
+        final FileSystemRepository repository = new DropBoxFileSystemRepository();
+        provider = new DropBoxFileSystemProvider(repository);
+
+        testDirectoryPath = "/test-" + UUID.randomUUID().toString();
+
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            Files.createDirectory(dropboxfs.getPath(testDirectoryPath));
+        }
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception
+    {
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception
+    {
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            deleteRecursive(dropboxfs, dropboxfs.getPath(testDirectoryPath));
+        }
+    }
+
+    private static void deleteRecursive(FileSystem fs, Path directoryPath) throws IOException
+    {
+        if (Files.exists(directoryPath))
+        {
+            try (DirectoryStream<Path> paths= Files.newDirectoryStream(directoryPath))
+            {
+                for (Path path : paths)
+                {
+                    if (Files.isDirectory(path))
+                    {
+                        deleteRecursive(fs, path);
+                    }
+                    else
+                    {
+                        Files.delete(fs.getPath(path.toString()));
+                    }
+                }
+            }
+            Files.delete(fs.getPath(directoryPath.toString()));
+        }
+    }
+
+    @Test(expectedExceptions = DropBoxIOException.class)
+    public void testDirectoryStreamRoot() throws IOException
+    {
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            Files.newDirectoryStream(dropboxfs.getPath(""));
+        }
+    }
+
+    @Test
+    public void testDirectoryStream() throws IOException
+    {
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            Files.newDirectoryStream(dropboxfs.getPath(testDirectoryPath));
+        }
+    }
+
+    @Test
+    public void testCreateFile() throws IOException
+    {
+        boolean thrown = false;
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            Path path = dropboxfs.getPath(testDirectoryPath + "/create_test");
+            Files.createFile(path);
+        }
+        catch (UnsupportedOperationException e)
+        {
+            thrown = true;
+        }
+        Assert.assertTrue(thrown);
+    }
+
+    @Test
+    public void testCreateDirectory() throws IOException
+    {
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            for (int i = 1; i <= 5; i++)
+            {
+                Path path = dropboxfs.getPath(testDirectoryPath + "/create_directory_test-" + i);
+                Path file = Files.createDirectory(path);
+                Assert.assertNotNull(file);
+                Assert.assertTrue(Files.exists(path));
+            }
+        }
+    }
+
+    @Test
+    public void testCreateDirectories() throws IOException
+    {
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            for (int i = 1; i <= 5; i++)
+            {
+                Path path = dropboxfs.getPath(testDirectoryPath + "/create_directories_test-" + i + "/sub_dir-" + i);
+                Path file = Files.createDirectories(path);
+                Assert.assertNotNull(file);
+                Assert.assertTrue(Files.exists(path));
+            }
+        }
+    }
+
+    @Test
+    public void testCreateDirectoryAlreadyExists() throws Exception
+    {
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            Path path = dropboxfs.getPath(testDirectoryPath + "/create_directory_already_exists_test");
+            Files.createDirectory(path);
+
+            boolean thrown = false;
+            try {
+                Files.createDirectory(path);
+            } catch (FileAlreadyExistsException e) {
+                thrown = true;
+            }
+            Assert.assertTrue(thrown);
+        }
+    }
+
+    @Test
+    public void testCopy() throws IOException
+    {
+        try
+        (
+            final FileSystem memfs = MemoryFileSystemBuilder.newEmpty().build("test");
+            final FileSystem dropboxfs = provider.newFileSystem(uri, env)
+        )
+        {
+            String contentOriginal = "This will be copied";
+            String contentCopy;
+
+            //create the source file in memory
+            Path source = memfs.getPath("/copy.txt");
+            Files.createFile(source);
+            Files.write(source, contentOriginal.getBytes());
+
+            //create the destination on Dropbox
+            Path dest = dropboxfs.getPath(testDirectoryPath + "/copy.txt");
+
+            //copy to Dropbox
+            Files.copy(source, dest);
+            Assert.assertTrue(Files.exists(dest));
+            Assert.assertTrue(Files.isRegularFile(dest));
+            try (InputStream in = Files.newInputStream(dest))
+            {
+                contentCopy = IOUtil.toUtf8String(in); //inputstream, SeekableByteChannel not supported
+            }
+            Assert.assertEquals(contentOriginal, contentCopy);
+
+            Files.delete(source);
+
+            //copy from Dropbox
+            Files.copy(dest, source);
+            Assert.assertTrue(Files.exists(source));
+            Assert.assertTrue(Files.isRegularFile(source));
+            contentCopy = new String(Files.readAllBytes(source));
+            Assert.assertEquals(contentOriginal, contentCopy);
+        }
+    }
+
+    @Test
+    public void testCopyAlreadyExists() throws IOException
+    {
+        try
+            (
+                final FileSystem memfs = MemoryFileSystemBuilder.newEmpty().build("test");
+                final FileSystem dropboxfs = provider.newFileSystem(uri, env)
+            )
+        {
+            Path source = memfs.getPath("/copy.txt");
+            Files.createFile(source);
+            Path dest = dropboxfs.getPath(testDirectoryPath + "/copy_already_exists.txt");
+
+            boolean thrown = false;
+
+            Files.copy(source, dest);
+            try
+            {
+                Files.copy(source, dest);
+            } catch (FileAlreadyExistsException e) {
+                thrown = true;
+            }
+            Assert.assertTrue(thrown);
+        }
+    }
+
+    @Test
+    public void testCheckAccessFile() throws IOException
+    {
+        try (final FileSystem memfs = MemoryFileSystemBuilder.newEmpty().build("test");
+             final FileSystem dropboxfs = provider.newFileSystem(uri, env)) {
+            Path source = memfs.getPath("/file.txt");
+            Files.createFile(source);
+            Path fileExists = dropboxfs.getPath(testDirectoryPath + "/checkAccess_file_exists.txt");
+            Files.copy(source, fileExists);
+
+            boolean thrown = false;
+
+            dropboxfs.provider().checkAccess(fileExists);
+            dropboxfs.provider().checkAccess(fileExists, AccessMode.READ);
+            dropboxfs.provider().checkAccess(fileExists, AccessMode.WRITE);
+            try {
+                dropboxfs.provider().checkAccess(fileExists, AccessMode.EXECUTE);
+            } catch (AccessDeniedException e) {
+                thrown = true;
+            }
+            Assert.assertTrue(thrown);
+        }
+    }
+
+    @Test
+    public void testCheckAccessNoSuchFile() throws IOException
+    {
+        try (final FileSystem memfs = MemoryFileSystemBuilder.newEmpty().build("test");
+             final FileSystem dropboxfs = provider.newFileSystem(uri, env)) {
+            Path noSuchFile = dropboxfs.getPath(testDirectoryPath + "/checkAccess_file_not_found.txt");
+
+            boolean thrown = false;
+
+            try {
+                dropboxfs.provider().checkAccess(noSuchFile);
+            } catch (NoSuchFileException e) {
+                thrown = true;
+            }
+            Assert.assertTrue(thrown);
+            thrown = false;
+            try {
+                dropboxfs.provider().checkAccess(noSuchFile, AccessMode.READ);
+            } catch (NoSuchFileException e) {
+                thrown = true;
+            }
+            Assert.assertTrue(thrown);
+            thrown = false;
+            try {
+                dropboxfs.provider().checkAccess(noSuchFile, AccessMode.WRITE);
+            } catch (NoSuchFileException e) {
+                thrown = true;
+            }
+            Assert.assertTrue(thrown);
+            thrown = false;
+            try {
+                dropboxfs.provider().checkAccess(noSuchFile, AccessMode.EXECUTE);
+            } catch (NoSuchFileException e) {
+                thrown = true;
+            }
+            Assert.assertTrue(thrown);
+        }
+    }
+
+
+    @Test
+    public void testCheckAccessDirectory() throws IOException
+    {
+        try (final FileSystem memfs = MemoryFileSystemBuilder.newEmpty().build("test");
+             final FileSystem dropboxfs = provider.newFileSystem(uri, env)) {
+            Path directory = Files.createDirectory(dropboxfs.getPath(testDirectoryPath + "/checkAccess_directory"));
+
+            boolean thrown = false;
+
+            try {
+                dropboxfs.provider().checkAccess(directory);
+            } catch (NoSuchFileException e) {
+                thrown = true;
+            }
+            Assert.assertFalse(thrown);
+            thrown = false;
+            try {
+                dropboxfs.provider().checkAccess(directory, AccessMode.READ);
+            } catch (NoSuchFileException e) {
+                thrown = true;
+            }
+            Assert.assertFalse(thrown);
+            thrown = false;
+            try {
+                dropboxfs.provider().checkAccess(directory, AccessMode.WRITE);
+            } catch (NoSuchFileException e) {
+                thrown = true;
+            }
+            Assert.assertFalse(thrown);
+            thrown = false;
+            try {
+                dropboxfs.provider().checkAccess(directory, AccessMode.EXECUTE);
+            } catch (NoSuchFileException e) {
+                thrown = true;
+            }
+            Assert.assertFalse(thrown);
+        }
+    }
+
+    @Test
+    public void testMoveDirectory() throws IOException
+    {
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            Path sourcePath = Files.createDirectory(dropboxfs.getPath(testDirectoryPath + "/moveDirectory_dir_source"));
+            Path targetPath = dropboxfs.getPath(testDirectoryPath + "/moveDirectory_dir_target");
+
+            Assert.assertFalse(Files.exists(targetPath));
+            Files.move(sourcePath, targetPath);
+            Assert.assertTrue(Files.exists(targetPath));
+        }
+    }
+
+    @Test(expectedExceptions = FileAlreadyExistsException.class)
+    public void testMoveDirectoryAlreadyExists() throws IOException
+    {
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env))
+        {
+            Path sourcePath = Files.createDirectory(dropboxfs.getPath(testDirectoryPath + "/moveDirectory_dir_already_exists_source"));
+            Path targetPath = Files.createDirectory(dropboxfs.getPath(testDirectoryPath + "/moveDirectory_dir_already_exists_target"));
+
+            Files.move(sourcePath, targetPath);
+        }
+    }
+
+    @Test
+    public void testMoveDirectoryReplaceExisting() throws IOException
+    {
+        try (final FileSystem dropboxfs = provider.newFileSystem(uri, env)) {
+            Path sourcePath = Files.createDirectory(dropboxfs.getPath(testDirectoryPath + "/moveDirectory_dir_replace_existing_source"));
+            Files.createDirectory(dropboxfs.getPath(testDirectoryPath + "/moveDirectory_dir_replace_existing_source/sub-dir"));
+            Path targetPath = Files.createDirectory(dropboxfs.getPath(testDirectoryPath + "/moveDirectory_dir_replace_existing_target"));
+            Path targetSubdirectoryPath = dropboxfs.getPath(testDirectoryPath + "/moveDirectory_dir_replace_existing_target/sub-dir");
+
+            Assert.assertFalse(Files.exists(targetSubdirectoryPath));
+            Files.move(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING);
+            Assert.assertTrue(Files.exists(targetSubdirectoryPath));
+        }
+    }
+
+    @Test
+    public void testMoveFile() throws IOException
+    {
+        try (final FileSystem memfs = MemoryFileSystemBuilder.newEmpty().build("test");
+             final FileSystem dropboxfs = provider.newFileSystem(uri, env)) {
+            Path source = Files.createFile(memfs.getPath("file.txt"));
+
+            Path dropboxSource = dropboxfs.getPath(testDirectoryPath + "/testMoveFile_file.txt");
+            Path dropboxTarget = dropboxfs.getPath(testDirectoryPath + "/testMoveFile_renamed_file.txt");
+
+            Files.copy(source, dropboxSource);
+            Assert.assertTrue(Files.exists(dropboxSource));
+
+            Files.move(dropboxSource, dropboxTarget);
+            Assert.assertTrue(Files.exists(dropboxTarget));
+        }
+    }
+
+    @Test(expectedExceptions = FileAlreadyExistsException.class)
+    public void testMoveFileAlreadyExists() throws IOException
+    {
+        try (final FileSystem memfs = MemoryFileSystemBuilder.newEmpty().build("test");
+             final FileSystem dropboxfs = provider.newFileSystem(uri, env)) {
+            Path source = Files.createFile(memfs.getPath("file.txt"));
+
+            Path dropboxSource = dropboxfs.getPath(testDirectoryPath + "/moveFile_file_already_exists_source.txt");
+            Path dropboxTarget = dropboxfs.getPath(testDirectoryPath + "/moveFile_file_already_exists_target.txt");
+
+            Files.copy(source, dropboxSource);
+            Files.copy(dropboxSource, dropboxTarget);
+            Files.move(dropboxSource, dropboxTarget);
+        }
+    }
+
+    @Test
+    public void testMoveFileReplaceExisting() throws IOException
+    {
+        try (final FileSystem memfs = MemoryFileSystemBuilder.newEmpty().build("test");
+             final FileSystem dropboxfs = provider.newFileSystem(uri, env)) {
+            Path source = Files.createFile(memfs.getPath("file.txt"));
+
+            Path dropboxSource = dropboxfs.getPath(testDirectoryPath + "/moveFile_file_replace_existing_source.txt");
+            Path dropboxTarget = dropboxfs.getPath(testDirectoryPath + "/moveFile_file_replace_existing_target.txt");
+
+            Files.copy(source, dropboxSource);
+            Files.copy(dropboxSource, dropboxTarget);
+            Files.move(dropboxSource, dropboxTarget, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    @Test(expectedExceptions = ReadOnlyAttributeException.class)
+    public void testMoveFileToForeignTarget() throws IOException
+    {
+        try (final FileSystem memfs = MemoryFileSystemBuilder.newEmpty().build("test");
+             final FileSystem dropboxfs = provider.newFileSystem(uri, env)) {
+            Path source = Files.createFile(memfs.getPath("file.txt"));
+            Path target = dropboxfs.getPath(testDirectoryPath + "/move_file_to_foreign_target_target.txt");
+
+            Files.move(source, target); // TODO: BasicFileAttributesProvider is readonly. I don't know if it has to be
+        }
+    }
+
+}

--- a/src/test/java/com/github/fge/fs/dropbox/FileSystemTest.java
+++ b/src/test/java/com/github/fge/fs/dropbox/FileSystemTest.java
@@ -32,7 +32,7 @@ import java.util.UUID;
 
 public class FileSystemTest
 {
-    private static final String ACCESS_TOKEN = "AYN4WsiaBTgAAAAAAAAAIL4iJnTphS5Ou9kbp3Wu2xA0BvktlbJPWCDukj76qhbs";
+    private static final String ACCESS_TOKEN = "yourAccessTokenHere";
     private static FileSystemProvider provider;
     private static URI uri;
     private static Map<String, String> env;

--- a/src/test/java/com/github/fge/fs/dropbox/attr/DropBoxBasicFileAttributesProviderTest.java
+++ b/src/test/java/com/github/fge/fs/dropbox/attr/DropBoxBasicFileAttributesProviderTest.java
@@ -1,0 +1,114 @@
+package com.github.fge.fs.dropbox.attr;
+
+import com.dropbox.core.util.LangUtil;
+import com.dropbox.core.v2.files.FileMetadata;
+import com.dropbox.core.v2.files.FolderMetadata;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.file.attribute.FileTime;
+import java.util.Date;
+
+public class DropBoxBasicFileAttributesProviderTest
+{
+//    private DropBoxBasicFileAttributesProvider nullProvider;
+    private DropBoxBasicFileAttributesProvider fileProvider;
+    private DropBoxBasicFileAttributesProvider folderProvider;
+
+    private Date date;
+    private long size;
+
+    @BeforeMethod
+    public void setUp() throws Exception
+    {
+//        nullProvider = new DropBoxBasicFileAttributesProvider(null); //not allowed (@Nonnull)
+
+        date = new Date();
+        size = 1L;
+        FileMetadata fileMetadata = FileMetadata.newBuilder("mockFile", "id", date, date, "123456789", size).build();
+        fileProvider = new DropBoxBasicFileAttributesProvider(fileMetadata);
+
+        FolderMetadata folderMetadata = FolderMetadata.newBuilder("mockFolder", "id").build();
+        folderProvider = new DropBoxBasicFileAttributesProvider(folderMetadata);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception
+    {
+    }
+
+//    @Test
+//    public void testLastModifiedTimeNull() throws Exception
+//    {
+//        Assert.assertTrue(nullProvider.lastModifiedTime(), FileTime.fromMillis(0L));
+//    }
+
+    @Test
+    public void testLastModifiedTimeFile() throws Exception
+    {
+        Assert.assertEquals(fileProvider.lastModifiedTime(), FileTime.fromMillis(LangUtil.truncateMillis(this.date).getTime()));
+    }
+
+    @Test
+    public void testLastModifiedTimeFolder() throws Exception
+    {
+        Assert.assertEquals(folderProvider.lastModifiedTime(), FileTime.fromMillis(0L));
+    }
+
+//    @Test
+//    public void testIsRegularFileNull() throws Exception
+//    {
+//        Assert.assertFalse(nullProvider.isRegularFile());
+//    }
+
+    @Test
+    public void testIsRegularFileFile() throws Exception
+    {
+        Assert.assertTrue(fileProvider.isRegularFile());
+    }
+
+    @Test
+    public void testIsRegularFileFolder() throws Exception
+    {
+        Assert.assertFalse(folderProvider.isRegularFile());
+    }
+
+//    @Test
+//    public void testIsDirectoryNull() throws Exception
+//    {
+//        Assert.assertFalse(nullProvider.isDirectory()); //TODO: not sure if intended, or if this should throw exception
+//    }
+
+    @Test
+    public void testIsDirectoryFile() throws Exception
+    {
+        Assert.assertFalse(fileProvider.isDirectory());
+    }
+
+    @Test
+    public void testIsDirectoryFolder() throws Exception
+    {
+        Assert.assertTrue(folderProvider.isDirectory());
+    }
+
+//    @Test
+//    public void testSizeNull() throws Exception
+//    {
+//        Assert.assertEquals(nullProvider.size(), 0L);
+//    }
+
+    @Test
+    public void testSizeFile() throws Exception
+    {
+        Assert.assertEquals(fileProvider.size(), size);
+    }
+
+    @Test
+    public void testSizeFolder() throws Exception
+    {
+        Assert.assertEquals(folderProvider.size(), 0L);
+    }
+
+}


### PR DESCRIPTION
The Dropbox v1 API has been retired on September 28, 2017.  
This migrates the repository to v2. Changes: 

- upgrade to version 3.0.4 of the dropbox-core-sdk library
- uses the Metadata (FileMetaData, FolderMetaData) instead of v1 DbxEntry
- various bug fixes 
- two test classes 26 test cases